### PR TITLE
Fix typo on var names in grid styl docs

### DIFF
--- a/views/css/modules/grid.jade
+++ b/views/css/modules/grid.jade
@@ -4,10 +4,10 @@ h3#grid grid
 
         grid()
 
-        column-width: 60px
-        gutter-width: 20px
-        columns: 12
-        total-width: 100%
+        column-width = 60px
+        gutter-width = 20px
+        columns = 12
+        total-width = 100%
 
         .main
         .sidebar


### PR DESCRIPTION
As stated on the docs of styl:
http://learnboost.github.com/stylus/docs/variables.html
Vars go with `=`

If the roots-css docs were followed then the example did not work. It would appear as
a fixed-width grid because the var was not overridden
